### PR TITLE
Minor Code Clean Up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # SystemIntegrityPSscript
-Scan Windows Dir if .exe, .dll,.sys == Get-FileHashsave to fileName | Path | Hash value
+
+Simple Powershell script writen by jaanuuna to find the md5 hash of files

--- a/systemintegrity_script.ps1
+++ b/systemintegrity_script.ps1
@@ -10,10 +10,8 @@ ForEach-Object {
         Hash = (Get-Filehash $_.fullname -algorithm md5).hash
 }}
 
-if ($result.length -lt 1) {
-        # write-host "no files found"
-    } else {
-        $result | Format-Table -auto | Out-File res.txt
+if ($result.length -gt 0) {
+        # $result | Format-Table -auto | Out-File res.txt
         $result | Format-Table -auto 
     }
 Write-Host "files found: "  $result.length

--- a/systemintegrity_script.ps1
+++ b/systemintegrity_script.ps1
@@ -1,19 +1,19 @@
-write-host "System Integrity PowerShell Script"
+Write-Host "System Integrity PowerShell Script"
 
 $result = @{}
-#  $result = get-childitem * -include *.dll,*.exe,*.sys |
-$result = get-childitem * -include *.txt |
+# $result = Get-ChildItem * -include *.dll,*.exe,*.sys |
+$result = Get-ChildItem * -include *.txt |
 
-foreach{
+ForEach-Object {
     [pscustomobject] @{
         File = $_.fullname
-        Hash = (get-filehash $_.fullname -algorithm md5).hash
+        Hash = (Get-Filehash $_.fullname -algorithm md5).hash
 }}
 
 if ($result.length -lt 1) {
         # write-host "no files found"
     } else {
-        $result | format-table -auto |out-file res.txt
-        $result | format-table -auto 
+        $result | Format-Table -auto | Out-File res.txt
+        $result | Format-Table -auto 
     }
-write-host "files found: "  $result.length
+Write-Host "files found: "  $result.length


### PR DESCRIPTION
Corrected the PowerShell function names to follow capitalization convention.

Fixed `foreach` to `ForEach-Object` as recommended by the IDE for stability.
